### PR TITLE
use custom Logger interface

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -6,14 +6,10 @@ github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02
 github.com/juju/testing	git	b8689951f6db31943dd8c3d540b8c4dd368cf850	2016-10-31T10:37:13Z
 github.com/juju/utils	git	ff639f825faac294524c2fff065f58fed5bcd77e	2016-11-01T02:02:32Z
 github.com/juju/version	git	4ae6172c00626779a5a462c3e3d22fc0e889431a	2016-06-03T19:49:58Z
-github.com/juju/zaputil	git	408606c4773b33dee045e934be253faa28c71cd4	2017-01-03T10:52:24Z
 github.com/lunixbochs/vtclean	git	4fbf7632a2c6d3fbdb9931439bdbbeded02cbe36	2016-01-25T03:51:06Z
 github.com/mattn/go-colorable	git	ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8	2016-07-31T23:54:17Z
 github.com/mattn/go-isatty	git	66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8	2016-08-06T12:27:52Z
-github.com/uber-go/atomic	git	9e99152552a6ce13fa3b2ce4a9c4fb117cca4506	2016-10-27T16:36:08Z
-github.com/uber-go/zap	git	05dadc4e239529c50d6f730c17f0a3aaf35b64fd	2016-12-12T17:30:18Z
 golang.org/x/crypto	git	f6b343c37ca80bfa8ea539da67a0b621f84fab1d	2016-12-21T23:57:47Z
-golang.org/x/net	git	ea47fc708ee3e20177f3ca3716217c4ab75942cb	2015-08-29T23:03:18Z
 golang.org/x/sys	git	9bb9f0998d48b31547d975974935ae9b48c7a03c	2016-10-12T00:19:20Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z
 gopkg.in/mgo.v2	git	f2b6f6c918c452ad107eec89615f074e3bd80e33	2016-08-18T01:52:18Z

--- a/session_test.go
+++ b/session_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	jujutesting "github.com/juju/testing"
-	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/mgosession"
@@ -16,31 +15,35 @@ type suite struct {
 	jujutesting.IsolatedMgoSuite
 }
 
+func (s *suite) TearDownTest(c *gc.C) {
+	s.IsolatedMgoSuite.TearDownTest(c)
+}
+
 var _ = gc.Suite(&suite{})
 
 func (s *suite) TestSession(c *gc.C) {
 	psession := jujutesting.NewProxiedSession(c)
 	defer psession.Close()
-	pool := mgosession.NewPool(context.TODO(), psession.Session, 2)
+	pool := mgosession.NewPool(nil, psession.Session, 2)
 	defer pool.Close()
 
 	// Obtain a session from the pool, then kill its connection
 	// so we can be sure that the next session is using a different
 	// connection
-	s0 := pool.Session(context.TODO())
+	s0 := pool.Session(nil)
 	defer s0.Close()
 	c.Assert(s0.Ping(), gc.IsNil)
 	psession.CloseConns()
 	c.Assert(s0.Ping(), gc.NotNil)
 
 	// The next session should still work.
-	s1 := pool.Session(context.TODO())
+	s1 := pool.Session(nil)
 	defer s1.Close()
 	c.Assert(s1.Ping(), gc.IsNil)
 
 	// The third session should cycle back to the first
 	// and fail.
-	s2 := pool.Session(context.TODO())
+	s2 := pool.Session(nil)
 	defer s2.Close()
 	c.Assert(s2.Ping(), gc.NotNil)
 
@@ -53,17 +56,17 @@ func (s *suite) TestSession(c *gc.C) {
 	// Resetting the pool should cause new sessions
 	// to work again.
 	pool.Reset()
-	s3 := pool.Session(context.TODO())
+	s3 := pool.Session(nil)
 	defer s3.Close()
 	c.Assert(s3.Ping(), gc.IsNil)
-	s4 := pool.Session(context.TODO())
+	s4 := pool.Session(nil)
 	defer s4.Close()
 	c.Assert(s4.Ping(), gc.IsNil)
 }
 
 func (s *suite) TestClosingPoolDoesNotClosePreviousSessions(c *gc.C) {
-	pool := mgosession.NewPool(context.TODO(), s.Session, 2)
-	session := pool.Session(context.TODO())
+	pool := mgosession.NewPool(nil, s.Session, 2)
+	session := pool.Session(nil)
 	defer session.Close()
 	pool.Close()
 	c.Assert(session.Ping(), gc.Equals, nil)
@@ -76,13 +79,13 @@ func (s *suite) TestSessionPinger(c *gc.C) {
 
 	psession := jujutesting.NewProxiedSession(c)
 	defer psession.Close()
-	pool := mgosession.NewPool(context.TODO(), psession.Session, 1)
+	pool := mgosession.NewPool(nil, psession.Session, 1)
 	defer pool.Close()
 
 	// Obtain a session from the pool, then kill its connection
 	// so we tell whether the next session from the pool uses
 	// the same connection.
-	s0 := pool.Session(context.TODO())
+	s0 := pool.Session(nil)
 	defer s0.Close()
 	c.Assert(s0.Ping(), gc.IsNil)
 	psession.CloseConns()
@@ -90,7 +93,7 @@ func (s *suite) TestSessionPinger(c *gc.C) {
 
 	// Sanity check that getting another session
 	// also gives us one that fails.
-	s1 := pool.Session(context.TODO())
+	s1 := pool.Session(nil)
 	defer s1.Close()
 	c.Assert(s0.Ping(), gc.NotNil)
 
@@ -111,7 +114,7 @@ func (s *suite) TestSessionPinger(c *gc.C) {
 	}
 
 	// Now the next session should be all fresh and lovely.
-	s2 := pool.Session(context.TODO())
+	s2 := pool.Session(nil)
 	defer s2.Close()
 	c.Assert(s2.Ping(), gc.IsNil)
 }


### PR DESCRIPTION
This avoids the dependency on the zap package, so packages
that aren't using that logging framework can use mgosession.