### PR TITLE
Avoid deadlock with pinger during Close()

### DIFF
--- a/session.go
+++ b/session.go
@@ -132,17 +132,20 @@ func (p *Pool) Session(logger Logger) *mgo.Session {
 // Close closes the pool. It may be called concurrently with other
 // Pool methods, but once called, a call to Session will panic.
 func (p *Pool) Close() {
+	// First stop the pinger so that it won't
+	// ask for any sessions after we're closed.
+	p.tomb.Kill(nil)
+	p.tomb.Wait()
+
+	// Then close everything down.
 	p.mu.Lock()
+	defer p.mu.Unlock()
 	if p.closed {
-		p.mu.Unlock()
 		return
 	}
-	p.tomb.Kill(nil)
 	p.closed = true
 	p.closeSessions()
 	p.session.Close()
-	p.mu.Unlock()
-	p.tomb.Wait()
 }
 
 // Reset resets the session pool so that no existing

--- a/session.go
+++ b/session.go
@@ -133,14 +133,15 @@ func (p *Pool) Session(logger Logger) *mgo.Session {
 // Pool methods, but once called, a call to Session will panic.
 func (p *Pool) Close() {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	if p.closed {
+		p.mu.Unlock()
 		return
 	}
 	p.tomb.Kill(nil)
 	p.closed = true
 	p.closeSessions()
 	p.session.Close()
+	p.mu.Unlock()
 	p.tomb.Wait()
 }
 


### PR DESCRIPTION
If the pinger attempts to acquire a session during Pool.Close, there
is a chance that they will mutually deadlock:
- Close attempts to kill the tomb and waits for all tracked goroutines
  to terminate. However, it does this with the mutex held.
- Meanwhile, the pinger attempts to obtain a session with
  Pool.Session and blocks on the mutex. Because it blocks, the pinger
  never gets to receive on the dying channel and terminate.

This PR releases the mutex before waiting on the tomb -- allowing the
pinger to proceed and clean up.

Log evidence of this scenario:

Waiting on the tomb in Pool.Close:
```
goroutine 743 [chan receive, 19 minutes]:
gopkg.in/tomb%2ev2.(*Tomb).Wait(0xc820230e70, 0x0, 0x0)
	/var/lib/jenkins/jobs/redacted-merge/workspace/gocode/src/gopkg.in/tomb.v2/tomb.go:116
+0x79
github.com/juju/mgosession.(*Pool).Close(0xc820230e70)
	/var/lib/jenkins/jobs/redacted-merge/workspace/gocode/src/github.com/juju/mgosession/session.go:144
+0x137
github.com/redacted/redacted/testing.(*MgoPoolSuite).TearDownTest(0xc82021cd50,
0xc82044e000)
	/var/lib/jenkins/jobs/redacted-merge/workspace/gocode/src/github.com/redacted/redacted/testing/mgosession.go:24
+0x5f
github.com/redacted/redacted/redacted/redacted/mgo_test.(*redacted).TearDownTest(0xc82021cd50,
0xc82044e000)
	/var/lib/jenkins/jobs/redacted-merge/workspace/gocode/src/github.com/redacted/redacted/redacted/redacted/redacted/redacted_test.go:324
+0x10d
reflect.Value.call(0xf363e0, 0xc82021cd50, 0xe13, 0xf5ee30, 0x4,
0xc8202edf10, 0x1, 0x1, 0x0, 0x0, ...)
	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/Go1.6/src/reflect/value.go:435
+0x1574
reflect.Value.Call(0xf363e0, 0xc82021cd50, 0xe13, 0xc8202edf10, 0x1,
0x1, 0x0, 0x0, 0x0)
	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/Go1.6/src/reflect/value.go:303
+0xce
gopkg.in/check%2ev1.(*suiteRunner).runFixture.func1(0xc82044e000)
	/var/lib/jenkins/jobs/redacted-merge/workspace/gocode/src/gopkg.in/check.v1/check.go:721
+0x1b9
gopkg.in/check%2ev1.(*suiteRunner).forkCall.func1(0xc8202c9b00,
0xc82044e000, 0x110bcc8)
	/var/lib/jenkins/jobs/redacted-merge/workspace/gocode/src/gopkg.in/check.v1/check.go:666
+0x81
created by gopkg.in/check%2ev1.(*suiteRunner).forkCall
	/var/lib/jenkins/jobs/redacted-merge/workspace/gocode/src/gopkg.in/check.v1/check.go:667
+0x48c
```

Meanwhile, the pinger is blocked:
```
goroutine 742 [semacquire, 19 minutes]:
sync.runtime_Semacquire(0xc820230ea4)
	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/Go1.6/src/runtime/sema.go:47
+0x26
sync.(*Mutex).Lock(0xc820230ea0)
	/var/lib/jenkins/tools/org.jenkinsci.plugins.golang.GolangInstallation/Go1.6/src/sync/mutex.go:83
+0x1ee
github.com/juju/mgosession.(*Pool).Session(0xc820230e70, 0x2b927b8f7670,
0xc8203920e0, 0x0)
	/var/lib/jenkins/jobs/redacted-merge/workspace/gocode/src/github.com/juju/mgosession/session.go:109
+0xd4
github.com/juju/mgosession.(*Pool).pinger(0xc820230e70, 0x2b927b8f7670,
0xc8203920e0, 0x0, 0x0)
	/var/lib/jenkins/jobs/redacted-merge/workspace/gocode/src/github.com/juju/mgosession/session.go:89
+0x177
github.com/juju/mgosession.NewPool.func1(0x0, 0x0)
	/var/lib/jenkins/jobs/redacted-merge/workspace/gocode/src/github.com/juju/mgosession/session.go:68
+0x59
gopkg.in/tomb%2ev2.(*Tomb).run(0xc820230e70, 0xc8202dac20)
	/var/lib/jenkins/jobs/redacted-merge/workspace/gocode/src/gopkg.in/tomb.v2/tomb.go:153
+0x2f
created by gopkg.in/tomb%2ev2.(*Tomb).Go
	/var/lib/jenkins/jobs/redacted-merge/workspace/gocode/src/gopkg.in/tomb.v2/tomb.go:149
+0x182
```