### PR TITLE
Fix for maxSessions.

### DIFF
--- a/session.go
+++ b/session.go
@@ -60,6 +60,9 @@ func NewPool(logger Logger, s *mgo.Session, maxSessions int) *Pool {
 	if logger == nil {
 		logger = nullLogger{}
 	}
+	if maxSessions < 1 {
+		maxSessions = 1
+	}
 	p := &Pool{
 		sessions: make([]*mgo.Session, maxSessions),
 		session:  s.Copy(),

--- a/session_test.go
+++ b/session_test.go
@@ -64,6 +64,22 @@ func (s *suite) TestSession(c *gc.C) {
 	c.Assert(s4.Ping(), gc.IsNil)
 }
 
+func (s *suite) TestMaxZeroSessions(c *gc.C) {
+	pool := mgosession.NewPool(nil, s.Session, 0)
+	defer pool.Close()
+
+	defer func() {
+		if r := recover(); r != nil {
+			c.Fatalf("test panicked: %v", r)
+		}
+	}()
+
+	// This must not panic
+	s0 := pool.Session(nil)
+	defer s0.Close()
+	c.Assert(s0.Ping(), gc.IsNil)
+}
+
 func (s *suite) TestClosingPoolDoesNotClosePreviousSessions(c *gc.C) {
 	pool := mgosession.NewPool(nil, s.Session, 2)
 	session := pool.Session(nil)


### PR DESCRIPTION
If the user specified zero (or negative) number of max sessions, the call to
pool.Session would panick.